### PR TITLE
$.trim search value

### DIFF
--- a/js/bootstrap-typeahead.js
+++ b/js/bootstrap-typeahead.js
@@ -134,7 +134,7 @@
         },
         ajaxLookup: function () {
 
-            var query = this.$element.val();
+            var query = $.trim(this.$element.val());
 
             if (query == this.query) {
                 return this;


### PR DESCRIPTION
When you type white spaces ajaxSource executes the request, trim the val fix the problem

var query = $.trim(this.$element.val())
